### PR TITLE
Update dependencies for node v12 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/peter-mouland/node-resemble-v2#readme",
   "dependencies": {
     "canvas": "^2.6.1",
-    "image-type": "^2.1.0",
+    "image-type": "^4.1.0",
     "resemblejs": "^v3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/peter-mouland/node-resemble-v2#readme",
   "dependencies": {
-    "canvas": "^1.6.2",
+    "canvas": "^2.6.1",
     "image-type": "^2.1.0",
-    "resemblejs": "^2.2.2"
+    "resemblejs": "^v3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/peter-mouland/node-resemble-v2#readme",
   "dependencies": {
-    "canvas": "^2.6.1",
+    "canvas": "^2.10.1",
     "image-type": "^4.1.0",
     "resemblejs": "^v3.2.4"
   }


### PR DESCRIPTION
I could not make the locked version of canvas work with node v12. While at it I updated other dependencies also to most recent version. I can confirm that the API works with latest node LTS v12.18.3, however I'm not sure if it's also compatible with older versions.